### PR TITLE
Do not replace nested model with new instance on .set('submodel', JSON)

### DIFF
--- a/lib/types/model.js
+++ b/lib/types/model.js
@@ -80,6 +80,32 @@ ModelAttribute = Attribute.inherit({
     toJSON: function () {
         return this.value.toJSON();
     },
+    
+    /**
+     * @override {Attribute}
+     */
+    isEqual: function (value) {                                                                                         
+        return this.value === value;                                                                                    
+    },                                                                                                                  
+                                                                                                                        
+    /**                                                                                                                 
+     * @override {Attribute}
+     * set attribute value                                                                                              
+     * @param {*} value                                                                                                 
+     */                                                                                                                 
+    set: function (value) {                                                                                             
+        if (value === null) {                                                                                           
+            this.unset();                                                                                               
+        } else if (!this.isEqual(value)) {                                                                              
+            if (value instanceof this.modelType) {                                                                      
+                this.value = value;                                                                                     
+            } else {                                                                                                    
+                this.value.set(value);                                                                                  
+            }                                                                                                           
+            this._isSet = true;                                                                                         
+            this._emitChange();                                                                                         
+        }                                                                                                               
+    },                                   
 
     /**
      * @override {Attribute}


### PR DESCRIPTION
Solution to next problem:

```
SubmodelModel = Model.inherit({
    attributes: {
        a: {...},
        b: {}
   }
});

ContainerModel = Model.inherit({
   attributes: {
      submodel: {
          type: 'Model',
          modelType: SubmodelModel
       }
   }
});
var container = new ContainerModel();
container.on('change:submodel', function () {
    console.log('submodel is changed');
});
container.get('submodel').set('a', 'qwerty'); //OK change callback is called
container.set('submodel', {a: 'qqqqq', b: 'zzzz'}) //FAIL change callback is not called
```
